### PR TITLE
Improve caching for apontamentos

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ def update_sharepoint_file(df):
         target_folder = ctx.web.get_folder_by_server_relative_url(folder_path)
         target_folder.upload_file(file_name_only, file_content).execute_query()
         st.cache_data.clear()
+        st.session_state["df_apontamentos"] = df
         st.success("Mudanças submetidas com sucesso! Recarregue a pagina para ver as mudanças")
     except Exception as e:
         locked = (
@@ -300,10 +301,11 @@ if tab_option == "Formulário":
                     novo_df = pd.DataFrame([novo_apontamento])
                     df = pd.concat([df, novo_df], ignore_index=True)
                     update_sharepoint_file(df)
+                    st.session_state["df_apontamentos"] = df
                     
 
 elif tab_option == "Lista de Apontamentos":
-    df = get_sharepoint_file()
+    df = st.session_state["df_apontamentos"]
     # Inicializa session state
     if "mostrar_campos_finais" not in st.session_state:
         st.session_state.mostrar_campos_finais = False
@@ -377,7 +379,6 @@ elif tab_option == "Lista de Apontamentos":
                     st.session_state.mostrar_campos_finais = True
                     st.session_state.indices_alterados = indices_alterados
                     st.session_state.df_atualizado = df
-                    st.rerun()
 
         # Campos obrigatórios + submissão
         if st.session_state.mostrar_campos_finais:
@@ -430,6 +431,7 @@ elif tab_option == "Lista de Apontamentos":
                         df.loc[idx, "Verificador"] = responsavel
 
                     update_sharepoint_file(df)
+                    st.session_state["df_apontamentos"] = df
 
                     # Reset estado
                     st.session_state.mostrar_campos_finais = False


### PR DESCRIPTION
## Summary
- avoid loading the SharePoint file on every rerun by keeping the DataFrame in session state
- update the cached DataFrame whenever changes are saved
- remove the explicit `st.rerun` call when editing status

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_684092c368f08332af3467ba82dc37c9